### PR TITLE
remote hostname label on logs (double with agent_hostname)

### DIFF
--- a/grafana-agent/Chart.yaml
+++ b/grafana-agent/Chart.yaml
@@ -3,5 +3,5 @@ name: grafana-agent
 description: Grafana Agent as used within SupplyStack
 type: application
 icon: https://slick-dev.github.io/helm/icons/supplystack.jpg
-version: 0.0.4
+version: 0.0.5
 

--- a/grafana-agent/templates/configmap-daemonset.yaml
+++ b/grafana-agent/templates/configmap-daemonset.yaml
@@ -14,7 +14,6 @@ data:
                 password: ${API_KEY}
               external_labels:
                 cluster: ${CLUSTER}
-                hostname: ${HOSTNAME}
           name: default
           positions:
             filename: /tmp/grafana-agent/positions/default.yml


### PR DESCRIPTION
Signed-off-by: Maarten De Wispelaere <maarten@bitprocessor.be>